### PR TITLE
Bug fix to GATKDoclet to set the default value to NA in all cases when i...

### DIFF
--- a/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/utils/help/GenericDocumentationHandler.java
+++ b/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/utils/help/GenericDocumentationHandler.java
@@ -196,7 +196,6 @@ public class GenericDocumentationHandler extends DocumentedGATKFeatureHandler {
                         argBindings.put("maxValue", "NA");
                         argBindings.put("minRecValue", "NA");
                         argBindings.put("maxRecValue", "NA");
-                        argBindings.put("defaultValue", "NA");
                     }
                     // Finalize argument bindings
                     args.get(kind).add(argBindings);


### PR DESCRIPTION
...t is missing.

The current code was doing this only for Numbers.
